### PR TITLE
Fix php warning after upgrade

### DIFF
--- a/serendipity_event_pinstyle.php
+++ b/serendipity_event_pinstyle.php
@@ -124,7 +124,8 @@ class serendipity_event_pinstyle extends serendipity_event
             "alt" => null,
             "image" => null
         ];
-        if ($html == '' || sizeof($html) == 0) {
+
+        if (empty($html)) {
             return $image;
         }
 


### PR DESCRIPTION
`$html` is not countable - prefer `empty()`.